### PR TITLE
build: switch to Node.js container, which has Python installed

### DIFF
--- a/.kokoro/release/docs.cfg
+++ b/.kokoro/release/docs.cfg
@@ -14,6 +14,12 @@ env_vars: {
     value: "gcr.io/cloud-devrel-kokoro-resources/python"
 }
 
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "nodejs-web-risk/.kokoro/trampoline.sh"
+
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/nodejs-web-risk/.kokoro/release/docs.sh"

--- a/.kokoro/release/docs.cfg
+++ b/.kokoro/release/docs.cfg
@@ -14,18 +14,6 @@ env_vars: {
     value: "gcr.io/cloud-devrel-kokoro-resources/python"
 }
 
-# Download trampoline resources.
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
-
-# Use the trampoline script to run in docker.
-build_file: "nodejs-web-risk/.kokoro/trampoline.sh"
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/python"
-}
-
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/nodejs-web-risk/.kokoro/release/docs.sh"

--- a/.kokoro/release/docs.cfg
+++ b/.kokoro/release/docs.cfg
@@ -11,7 +11,7 @@ before_action {
 # doc publications use a Python image.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/python"
+    value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
 }
 
 # Download trampoline resources.

--- a/.kokoro/release/docs.sh
+++ b/.kokoro/release/docs.sh
@@ -21,7 +21,8 @@ if [[ -z "$CREDENTIALS" ]]; then
   # if CREDENTIALS are explicitly set, assume we're testing locally
   # and don't set NPM_CONFIG_PREFIX.
   export NPM_CONFIG_PREFIX=/home/node/.npm-global
-  cd $(dirname $0)/..
+  export PATH="$PATH:/home/node/.npm-global/bin"
+  cd $(dirname $0)/../..
 fi
 npm install
 npm run docs

--- a/.kokoro/release/docs.sh
+++ b/.kokoro/release/docs.sh
@@ -21,6 +21,7 @@ if [[ -z "$CREDENTIALS" ]]; then
   # if CREDENTIALS are explicitly set, assume we're testing locally
   # and don't set NPM_CONFIG_PREFIX.
   export NPM_CONFIG_PREFIX=/home/node/.npm-global
+  cd $(dirname $0)/../..
 fi
 npm install
 npm run docs

--- a/.kokoro/release/docs.sh
+++ b/.kokoro/release/docs.sh
@@ -28,7 +28,7 @@ npm run docs
 
 # create docs.metadata, based on package.json and .repo-metadata.json.
 npm i json@9.0.6 -g
-python3 -m pip install gcp-docuploader
+python3 -m pip install --user gcp-docuploader
 python3 -m docuploader create-metadata \
   --name=$(cat .repo-metadata.json | json name) \
   --version=$(cat package.json | json version) \

--- a/.kokoro/release/docs.sh
+++ b/.kokoro/release/docs.sh
@@ -21,7 +21,7 @@ if [[ -z "$CREDENTIALS" ]]; then
   # if CREDENTIALS are explicitly set, assume we're testing locally
   # and don't set NPM_CONFIG_PREFIX.
   export NPM_CONFIG_PREFIX=/home/node/.npm-global
-  cd $(dirname $0)/../..
+  cd $(dirname $0)/..
 fi
 npm install
 npm run docs

--- a/.kokoro/release/docs.sh
+++ b/.kokoro/release/docs.sh
@@ -16,12 +16,11 @@
 
 set -eo pipefail
 
-# generate documentation with Node.js.
+# build jsdocs (Python is installed on the Node 10 docker image).
 if [[ -z "$CREDENTIALS" ]]; then
-  # if CREDENTIALS is not set, assume we're in a remote environment
-  # and configure Node.js.
-  curl -sL https://deb.nodesource.com/setup_10.x | bash -
-  apt-get install -y nodejs
+  # if CREDENTIALS are explicitly set, assume we're testing locally
+  # and don't set NPM_CONFIG_PREFIX.
+  export NPM_CONFIG_PREFIX=/home/node/.npm-global
 fi
 npm install
 npm run docs

--- a/.kokoro/release/docs.sh
+++ b/.kokoro/release/docs.sh
@@ -18,9 +18,10 @@ set -eo pipefail
 
 # build jsdocs (Node 8.16.0 is currently installed on Python image).
 if [[ -z "$CREDENTIALS" ]]; then
-  # if CREDENTIALS are explicitly set, assume we're testing locally
-  # and don't set NPM_CONFIG_PREFIX.
-  export NPM_CONFIG_PREFIX=/home/node/.npm-global
+  # if CREDENTIALS is not set, assume we're in a remote environment
+  # and configure Node.js.
+  curl -sL https://deb.nodesource.com/setup_10.x | bash -
+  apt-get install -y nodejs
 fi
 npm install
 npm run docs

--- a/.kokoro/release/docs.sh
+++ b/.kokoro/release/docs.sh
@@ -16,7 +16,7 @@
 
 set -eo pipefail
 
-# build jsdocs (Node 8.16.0 is currently installed on Python image).
+# generate documentation with Node.js.
 if [[ -z "$CREDENTIALS" ]]; then
   # if CREDENTIALS is not set, assume we're in a remote environment
   # and configure Node.js.

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -7,7 +7,7 @@
   "release_level": "beta",
   "language": "nodejs",
   "repo": "googleapis/nodejs-web-risk",
-  "distribution_name": "@google-cloud/datalabeling",
+  "distribution_name": "@google-cloud/web-risk",
   "api_id": "webrisk.googleapis.com",
   "requires_billing": true
 }


### PR DESCRIPTION
I was mistaken about Node.js being available on the `python` image (I was running the wrong container version).

This is a stop gap to test things end-to-end, while I work on publishing a custom image.