### PR TITLE
test: add a smoke test for x-googl-api-client header being set

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-node": "^9.0.1",
     "eslint-plugin-prettier": "^3.0.1",
+    "http2spy": "^1.0.0",
     "jsdoc": "^3.5.5",
     "jsdoc-fresh": "^1.0.1",
     "linkinator": "^1.4.0",

--- a/system-test/header.js
+++ b/system-test/header.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019, Google, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const {assert} = require('chai');
+const http2spy = require('http2spy');
+const {WebRiskServiceV1Beta1Client} = http2spy.require(require.resolve('../'));
+
+describe('header', () => {
+  it('populates x-goog-api-client header', async () => {
+    const client = new WebRiskServiceV1Beta1Client();
+    const request = {
+      uri: 'http://testsafebrowsing.appspot.com/s/malware.html',
+      threatTypes: ['MALWARE'],
+    };
+    await client.searchUris(request);
+    assert.ok(
+      /^gl-node\/[0-9]+\.[\w.-]+ grpc\/[\w.-]+ gax\/[\w.-]+ gapic\/[\w.-]+$/.test(
+        http2spy.requests[0]['x-goog-api-client'][0]
+      )
+    );
+  });
+});


### PR DESCRIPTION
adds a smoke test for `x-goog-api-client` being appropriately populated, this is currently blocked by:

https://github.com/googleapis/gapic-generator/pull/2929

