### PR TITLE
fix: version rearrange

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,12 @@
 // ** https://github.com/googleapis/synthtool **
 // ** All changes to this file may be overwritten. **
 
-import * as v1beta1 from './v1beta1';
 import * as v1 from './v1';
+import * as v1beta1 from './v1beta1';
 
 const WebRiskServiceClient = v1.WebRiskServiceClient;
 
-export {v1beta1, v1, WebRiskServiceClient};
-export default {v1beta1, v1, WebRiskServiceClient};
+export {v1, v1beta1, WebRiskServiceClient};
+export default {v1, v1beta1, WebRiskServiceClient};
 import * as protos from '../protos/protos';
 export {protos};

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,12 @@
 // ** https://github.com/googleapis/synthtool **
 // ** All changes to this file may be overwritten. **
 
-import * as v1 from './v1';
 import * as v1beta1 from './v1beta1';
+import * as v1 from './v1';
 
 const WebRiskServiceClient = v1.WebRiskServiceClient;
 
-export {v1, v1beta1, WebRiskServiceClient};
-export default {v1, v1beta1, WebRiskServiceClient};
+export {v1beta1, v1, WebRiskServiceClient};
+export default {v1beta1, v1, WebRiskServiceClient};
 import * as protos from '../protos/protos';
 export {protos};

--- a/synth.metadata
+++ b/synth.metadata
@@ -4,22 +4,22 @@
       "git": {
         "name": ".",
         "remote": "git@github.com:googleapis/nodejs-web-risk.git",
-        "sha": "acc862922b55578929cee8171066d703bcd10ae7"
+        "sha": "c1d0bb781ff10e959217f3630eaa0872fa0d9694"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "edd3b80fb770548d6ad780105f1782de6ff73ea0",
-        "internalRef": "311053644"
+        "sha": "eafa840ceec23b44a5c21670288107c661252711",
+        "internalRef": "313488995"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "98c50772ec23295c64cf0d2ddf199ea52961fd4c"
+        "sha": "c191450fc462f5e6e8d5c3bb6aeae23102b786ea"
       }
     }
   ],
@@ -28,7 +28,7 @@
       "client": {
         "source": "googleapis",
         "apiName": "webrisk",
-        "apiVersion": "v1",
+        "apiVersion": "v1beta1",
         "language": "typescript",
         "generator": "gapic-generator-typescript"
       }
@@ -37,7 +37,7 @@
       "client": {
         "source": "googleapis",
         "apiName": "webrisk",
-        "apiVersion": "v1beta1",
+        "apiVersion": "v1",
         "language": "typescript",
         "generator": "gapic-generator-typescript"
       }

--- a/synth.metadata
+++ b/synth.metadata
@@ -4,22 +4,22 @@
       "git": {
         "name": ".",
         "remote": "git@github.com:googleapis/nodejs-web-risk.git",
-        "sha": "c1d0bb781ff10e959217f3630eaa0872fa0d9694"
+        "sha": "0e33c96b6d551673e8ab584bb0b33ddd7d3672fa"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "eafa840ceec23b44a5c21670288107c661252711",
-        "internalRef": "313488995"
+        "sha": "f72c3a53fe6705cd705b4fc4e464bed4dbd1f18f",
+        "internalRef": "314606371"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "c191450fc462f5e6e8d5c3bb6aeae23102b786ea"
+        "sha": "f06a850db98490bf90c6a476d3f4c6c7cdfb1e5e"
       }
     }
   ],

--- a/synth.py
+++ b/synth.py
@@ -24,7 +24,7 @@ AUTOSYNTH_MULTIPLE_COMMITS = True
 
 # run the gapic generator
 gapic = gcp.GAPICMicrogenerator()
-versions = ['v1', 'v1beta1']
+versions = ['v1beta1', 'v1']
 for version in versions:
     library = gapic.typescript_library(
         'webrisk',

--- a/synth.py
+++ b/synth.py
@@ -24,8 +24,15 @@ AUTOSYNTH_MULTIPLE_COMMITS = True
 
 # run the gapic generator
 gapic = gcp.GAPICMicrogenerator()
-versions = ['v1beta1', 'v1']
-for version in versions:
+versions = ['v1', 'v1beta1']
+default_version = 'v1'
+
+# Rearrange the default version to the last item in the array, to generate appropriate system-test
+order_versions = versions.copy()
+order_versions.append(order_versions.pop(
+    order_versions.index(default_version)))
+
+for version in order_versions:
     library = gapic.typescript_library(
         'webrisk',
         generator_args={
@@ -39,7 +46,7 @@ for version in versions:
 # Copy common templates
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(
-    source_location='build/src', versions=versions, default_version='v1')
+    source_location='build/src', versions=versions, default_version=default_version)
 s.copy(templates, excludes=['.nycrc'])
 
 node.postprocess_gapic_library()

--- a/system-test/fixtures/sample/src/index.js
+++ b/system-test/fixtures/sample/src/index.js
@@ -20,7 +20,7 @@
 const webrisk = require('@google-cloud/web-risk');
 
 function main() {
-  const webRiskServiceV1Beta1Client = new webrisk.v1beta1.WebRiskServiceV1Beta1Client();
+  const webRiskServiceClient = new webrisk.WebRiskServiceClient();
 }
 
 main();

--- a/system-test/fixtures/sample/src/index.ts
+++ b/system-test/fixtures/sample/src/index.ts
@@ -16,10 +16,10 @@
 // ** https://github.com/googleapis/gapic-generator-typescript **
 // ** All changes to this file may be overwritten. **
 
-import * as webrisk from '@google-cloud/web-risk';
+import {WebRiskServiceClient} from '@google-cloud/web-risk';
 
 function main() {
-  new webrisk.v1beta1.WebRiskServiceV1Beta1Client();
+  new WebRiskServiceClient();
 }
 
 main();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,8 +17,8 @@ const path = require('path');
 module.exports = {
   entry: './src/index.ts',
   output: {
-    library: 'WebRiskServiceV1Beta1',
-    filename: './web-risk-service-v1-beta1.js',
+    library: 'WebRiskService',
+    filename: './web-risk-service.js',
   },
   node: {
     child_process: 'empty',


### PR DESCRIPTION
temporarily avoid #162
in the synth.py, the generated lib version ordered by the versions list.
move the default version to the last item of the list could overwrite the system-test for default instead of beta.

working on long-term solution in synthtool (https://github.com/googleapis/synthtool/issues/584)